### PR TITLE
Set max_filedescriptors to 65536 in squid.conf

### DIFF
--- a/squid/5/squid.conf
+++ b/squid/5/squid.conf
@@ -46,3 +46,4 @@ refresh_pattern (Release|Packages(.gz)*)$      0       20%     2880
 refresh_pattern .        0    20%    4320
 maximum_object_size 1024 MB
 max_filedescriptors 65536
+

--- a/squid/5/squid.conf
+++ b/squid/5/squid.conf
@@ -45,3 +45,4 @@ refresh_pattern -i (/cgi-bin/|\?) 0    0%    0
 refresh_pattern (Release|Packages(.gz)*)$      0       20%     2880
 refresh_pattern .        0    20%    4320
 maximum_object_size 1024 MB
+max_filedescriptors 65536

--- a/squid/6/squid.conf
+++ b/squid/6/squid.conf
@@ -46,3 +46,4 @@ refresh_pattern (Release|Packages(.gz)*)$      0       20%     2880
 refresh_pattern .        0    20%    4320
 maximum_object_size 1024 MB
 max_filedescriptors 65536
+

--- a/squid/6/squid.conf
+++ b/squid/6/squid.conf
@@ -45,3 +45,4 @@ refresh_pattern -i (/cgi-bin/|\?) 0    0%    0
 refresh_pattern (Release|Packages(.gz)*)$      0       20%     2880
 refresh_pattern .        0    20%    4320
 maximum_object_size 1024 MB
+max_filedescriptors 65536


### PR DESCRIPTION
Replicating the changes made to the Ubuntu squid base image in https://code.launchpad.net/~athos-ribeiro/ubuntu-docker-images/+git/squid/+merge/424521

Fix for https://bugs.launchpad.net/ubuntu-docker-images/+bug/1978272 - Squid attempting to open extremely high amounts of memory blocks on the system when running in containers on certain host OS's